### PR TITLE
Some improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,10 @@
 [deps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Debugger = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 PyMNE = "6c5003b2-cbe8-491c-a0d1-70088e6a0fd6"

--- a/task-01.jl
+++ b/task-01.jl
@@ -1,13 +1,16 @@
 using Unfold, StatsModels
 
 # init Plots
-using Plots
+using Plots # I dont use Plots but Makie.jl
 plotly()
 include("utils.jl")
 
 
 # define dataset path
 path = "data/sub-45/eeg/sub-45_task-WLFO_eeg.set"
+if !isfile(path)
+    path = "/store/data/WLFO/derivatives/preproc_agert/sub-45/eeg/sub-45_task-WLFO_eeg.set"
+end
 # raw, events = read_mne_eeglab(path, 128)
 # data = raw.get_data()
 
@@ -15,25 +18,41 @@ path = "data/sub-45/eeg/sub-45_task-WLFO_eeg.set"
 data, events = read_eeglab_with_all_events(path, sfreq=128)
  
 # define formula 
-f = @formula 0~1 + sac_amplitude
+f = @formula 0~1 +  sac_amplitude # also tried + sac_vmax with interesting results
+
 
 # select only fixation
 events = events[events.type .== "fixation",:]
+events[!,:sac_amplitude] = Float64.(events.sac_amplitude)
+events[!,:sac_vmax] = Float64.(events.sac_vmax)
+
+
 
 #= Source: Unfold Documentation
 Since, Deconvolution works on continuous data, to compare it to the “normal” use-case, we have to epoch it. 
 Data cleaning is doing in the fuction definition 
 We additionally remove trials from unfold.X that were removed during epoching 
 =#
-beta, times = Unfold.epoch(data=data, tbl=events, τ=(-1.0, 1.9), sfreq=128) # cut the data into epochs
+beta, times = Unfold.epoch(data=data, tbl=events, τ=(-0.3, 0.5), sfreq=128) # cut the data into epochs
+
+beta[:,:,isnan.(events.sac_vmax)] .= missing # to run with sac_vmax
 
 # Special solver solver_lsmr_b2b with b2b regression
-se_solver = solver = (x, y) -> Unfold.solver_b2b(x, y)
+
+# depending on unfold version, you might not be able to use the named argument, but have to put solver_b2b(x,y,1)
+se_solver = solver = (x, y) -> Unfold.solver_b2b(x, y,cross_val_reps = 5)
+
 
 # Generate Designmatrix & fit mass-univariate model (one model per epoched-timepoint) 
 model, results_expanded = Unfold.fit(UnfoldLinearModel, f, events, beta, times, solver=se_solver)
 
-# select a channel? Is it necessary?
+include("dev/Unfold/src/plot.jl") # install Makie first, also run ]dev --local Unfold   to get a "local copy" of Unfold in the folder ./dev/Unfold
+
+plot_results(results_expanded,layout_x=:basisname) # the layout_x is needed because group=nothing and the plotting function doesnt like that...
+
+#--- didnt look further than that, but noticed I havent implemented B2B for 2D data yet (necessary for deconvolution) - but it should be very simple to do.
+
+# select a channel? Is it necessary?plo
 results = results_expanded[results_expanded.channel.==1,:]
 plot(x = results[:colname_basis], y = results[:estimate])
 


### PR DESCRIPTION
regarding plottiing: There is not much yet, there exists https://github.com/unfoldtoolbox/Unfold.jl/blob/main/src/plot.jl with a single function to plot the results, but I need to write the functions still. That was one idea for a FachPraktikum ;) In order to use the function you need to include it (include("pathToFile")). then plot_results(res) with m,res = fit(UnfoldLinearModel ...). You need to install AlgebraOfGraphics and GLMakie first though.


Regarding runtime: Your epoch was very large, I changed it to [-0.3,0.5], also I changed how often the cross validation is repeated from 10 to 1 - had to fix a thing in Unfold, so maybe do a "]up Unfold#master" to get latest version.
Ah, now I see what happened. Your events dataframe does not have any types asserted. Thus the toolbox thinks your predictor is categorical instead of continuous and tries to generate 1000 categories.
Thus do a
`events[!,:sac_amplitude] = Float64.(events.sac_amplitude)` # note the ! which tells the dataframe to replace the type as well [I think...]

And it works muuuuuch faster.

I also introduced vmax which I think is interesting. I dont understand the pattern though, maybe because I dont yet understand the univariate effect of vmax in the first place ;-) but I thought sac_amplitude decoding should be reduced, if you introduce a strongly correlated predictor like vmax.